### PR TITLE
Add Gradle support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 out/
-*.iml
+.gradle/
 
+bin/
+build/
 test-ty/
-src/test/java/

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,24 @@
+apply plugin: 'java'
+apply plugin: 'application'
+
+mainClassName = "com.github.chrisblutz.trinity.Trinity"
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java']
+        }
+    }
+}
+
+tasks.withType(Jar) {
+    destinationDir = file('bin/')
+}
+
+jar {
+    manifest {
+        attributes (
+            'Main-Class': mainClassName
+        )
+    }
+}


### PR DESCRIPTION
Adds Gradle support to Trinity, allowing for easier building and easier testing when the unit-testing library is added.